### PR TITLE
chore: Add "yq" to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,4 +2,6 @@ FROM mcr.microsoft.com/devcontainers/base:debian
 
 RUN apt update -y \
     && apt install -y --no-install-recommends shellcheck \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*  \
+    && wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq &&\
+    chmod +x /usr/local/bin/yq


### PR DESCRIPTION
It is used to parse "action.yml" file to lint "run" field.